### PR TITLE
Adds license badge to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# matterbridge
+# matterbridge 
+
+[![Apache License](https://img.shields.io/:license-Apache%20License%20(ASL)-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 Simple bridge between mattermost and IRC. Uses the in/outgoing webhooks.  
 Relays public channel messages between mattermost and IRC.  


### PR DESCRIPTION
I dislike having to open the`LICENSE` file in order to see what the license of a project is, so I though adding a license badge might be a nice addition.

If this isn't in line with your way of thinking, feel free to close this PR un-merged.
